### PR TITLE
Wire delle syscall dei semafori in DisastrOS (stub, build pulita)

### DIFF
--- a/source/08_disastrOS/disastrOS_01_structures/Makefile
+++ b/source/08_disastrOS/disastrOS_01_structures/Makefile
@@ -7,12 +7,13 @@ RM=rm -f
 CPPFLAGS=-I.
 
 HEADERS=disastrOS.h\
-	disastrOS_constants.h\
-	disastrOS_globals.h\
-	disastrOS_pcb.h\
-	disastrOS_syscalls.h\
-	linked_list.h\
-	pool_allocator.h
+        disastrOS_constants.h\
+        disastrOS_globals.h\
+        disastrOS_pcb.h\
+        disastrOS_syscalls.h\
+        disastrOS_semaphores.h\
+        linked_list.h\
+        pool_allocator.h
 
 OBJS=pool_allocator.o\
      linked_list.o\
@@ -25,6 +26,8 @@ OBJS=pool_allocator.o\
      disastrOS_shutdown.o\
      disastrOS_schedule.o\
      disastrOS_preempt.o\
+     disastrOS_semaphores.o\
+     disastrOS_sem_syscalls.o\
 
 LIBS=libdisastrOS.a
 BINS=disastrOS_test

--- a/source/08_disastrOS/disastrOS_01_structures/disastrOS.c
+++ b/source/08_disastrOS/disastrOS_01_structures/disastrOS.c
@@ -8,6 +8,7 @@
 #include <unistd.h>
 #include "disastrOS.h"
 #include "disastrOS_syscalls.h"
+#include "disastrOS_semaphores.h"
 
 
 
@@ -89,6 +90,7 @@ void disastrOS_start(void (*f)(void*), void* f_args, char* logfile){
   /* INITIALIZATION OF SYSTEM STRUCTURES*/
   disastrOS_debug("initializing system structures\n");
   PCB_init();
+  Sem_init();
   init_pcb=0;
 
   // populate the vector of syscalls and number of arguments for each syscall
@@ -112,6 +114,18 @@ void disastrOS_start(void (*f)(void*), void* f_args, char* logfile){
 
   syscall_vector[DSOS_CALL_SHUTDOWN]      = internal_shutdown;
   syscall_numarg[DSOS_CALL_SHUTDOWN]      = 0;
+
+  syscall_vector[DSOS_CALL_SEMOPEN]      = internal_semOpen;
+  syscall_numarg[DSOS_CALL_SEMOPEN]      = 2;
+
+  syscall_vector[DSOS_CALL_SEMCLOSE]     = internal_semClose;
+  syscall_numarg[DSOS_CALL_SEMCLOSE]     = 1;
+
+  syscall_vector[DSOS_CALL_SEMWAIT]      = internal_semWait;
+  syscall_numarg[DSOS_CALL_SEMWAIT]      = 1;
+
+  syscall_vector[DSOS_CALL_SEMPOST]      = internal_semPost;
+  syscall_numarg[DSOS_CALL_SEMPOST]      = 1;
 
   // setup the scheduling lists
   running=0;
@@ -154,6 +168,22 @@ void disastrOS_spawn(void (*f)(void*), void* args ) {
 
 void disastrOS_shutdown() {
   disastrOS_syscall(DSOS_CALL_SHUTDOWN);
+}
+
+int disastrOS_semOpen(int id, int init){
+  return disastrOS_syscall(DSOS_CALL_SEMOPEN, id, init);
+}
+
+int disastrOS_semClose(int id){
+  return disastrOS_syscall(DSOS_CALL_SEMCLOSE, id);
+}
+
+int disastrOS_semWait(int id){
+  return disastrOS_syscall(DSOS_CALL_SEMWAIT, id);
+}
+
+int disastrOS_semPost(int id){
+  return disastrOS_syscall(DSOS_CALL_SEMPOST, id);
 }
 
 int disastrOS_getpid(){

--- a/source/08_disastrOS/disastrOS_01_structures/disastrOS.h
+++ b/source/08_disastrOS/disastrOS_01_structures/disastrOS.h
@@ -28,5 +28,10 @@ void disastrOS_preempt();
 void disastrOS_spawn(void (*f)(void*), void* args );
 void disastrOS_shutdown();
 
+int disastrOS_semOpen(int id, int init);
+int disastrOS_semClose(int id);
+int disastrOS_semWait(int id);
+int disastrOS_semPost(int id);
+
 // debug function, prints the state of the internal system
 void disastrOS_printStatus();

--- a/source/08_disastrOS/disastrOS_01_structures/disastrOS_constants.h
+++ b/source/08_disastrOS/disastrOS_01_structures/disastrOS_constants.h
@@ -27,6 +27,10 @@
 #define DSOS_CALL_SPAWN     5
 #define DSOS_CALL_SLEEP     6
 #define DSOS_CALL_SHUTDOWN  7
+#define DSOS_CALL_SEMOPEN   8
+#define DSOS_CALL_SEMCLOSE  9
+#define DSOS_CALL_SEMWAIT   10
+#define DSOS_CALL_SEMPOST   11
 
 // scheduling
 #define ALPHA 0.5f

--- a/source/08_disastrOS/disastrOS_01_structures/disastrOS_sem_syscalls.c
+++ b/source/08_disastrOS/disastrOS_01_structures/disastrOS_sem_syscalls.c
@@ -1,0 +1,27 @@
+#include <assert.h>
+#include <unistd.h>
+#include <stdio.h>
+#include "disastrOS.h"
+#include "disastrOS_syscalls.h"
+#include "disastrOS_semaphores.h"
+
+void internal_semOpen(){
+  running->syscall_retvalue = DSOS_ESYSCALL_NOT_IMPLEMENTED;
+  return;
+}
+
+void internal_semClose(){
+  running->syscall_retvalue = DSOS_ESYSCALL_NOT_IMPLEMENTED;
+  return;
+}
+
+void internal_semWait(){
+  running->syscall_retvalue = DSOS_ESYSCALL_NOT_IMPLEMENTED;
+  return;
+}
+
+void internal_semPost(){
+  running->syscall_retvalue = DSOS_ESYSCALL_NOT_IMPLEMENTED;
+  return;
+}
+

--- a/source/08_disastrOS/disastrOS_01_structures/disastrOS_semaphores.c
+++ b/source/08_disastrOS/disastrOS_01_structures/disastrOS_semaphores.c
@@ -1,0 +1,5 @@
+#include "disastrOS_semaphores.h"
+
+void Sem_init(void) {
+}
+

--- a/source/08_disastrOS/disastrOS_01_structures/disastrOS_semaphores.h
+++ b/source/08_disastrOS/disastrOS_01_structures/disastrOS_semaphores.h
@@ -1,0 +1,9 @@
+#pragma once
+
+// placeholder structure for semaphores
+typedef struct Sem {
+  int dummy;
+} Sem;
+
+void Sem_init(void);
+

--- a/source/08_disastrOS/disastrOS_01_structures/disastrOS_syscalls.h
+++ b/source/08_disastrOS/disastrOS_01_structures/disastrOS_syscalls.h
@@ -15,4 +15,15 @@ void internal_spawn();
 
 void internal_shutdown();
 
+void internal_semOpen();
+void internal_semClose();
+void internal_semWait();
+void internal_semPost();
+
 void internal_schedule();
+
+// user-level semaphore API
+int disastrOS_semOpen(int id, int init);
+int disastrOS_semClose(int id);
+int disastrOS_semWait(int id);
+int disastrOS_semPost(int id);

--- a/source/08_disastrOS/disastrOS_01_structures/docs/semaphores.md
+++ b/source/08_disastrOS/disastrOS_01_structures/docs/semaphores.md
@@ -1,0 +1,11 @@
+# Semaphores API
+
+- `disastrOS_semOpen(id, init)` opens or creates a semaphore with initial count `init`.
+- `disastrOS_semClose(id)` releases the semaphore.
+- `disastrOS_semWait(id)` decrements the semaphore and possibly blocks.
+- `disastrOS_semPost(id)` increments the semaphore and wakes a waiter if any.
+- `count` represents available resources; negative `count` tracks waiting processes.
+- Invariant: `count >= 0` implies no process is waiting.
+- Invariant: `count < 0` implies `abs(count)` processes are waiting.
+- Waiters are served in FIFO order.
+


### PR DESCRIPTION
## Summary
- Add semaphore syscall numbers and userland wrappers
- Provide stubbed semaphore module and syscall handlers returning `DSOS_ESYSCALL_NOT_IMPLEMENTED`
- Register SEM* syscalls in the syscall table and document semaphore invariants

## Testing
- `make`
- `./disastrOS_test`


------
https://chatgpt.com/codex/tasks/task_e_68ab4a2f2868832798ffb3fe29211c38